### PR TITLE
Merge feature/uninstall-hook-automatically-on-dead-receiverref

### DIFF
--- a/src/NeatInput.Windows/IInputSource.cs
+++ b/src/NeatInput.Windows/IInputSource.cs
@@ -9,6 +9,11 @@ namespace NeatInput.Windows
     public interface IInputSource : IDisposable
     {
         /// <summary>
+        /// Controls if the affected hook is unset when the correspondending receiver died.
+        /// </summary>
+        bool UnsetHookOnReceiverDead { get; set; }
+
+        /// <summary>
         /// This method sets the mouse and/or the keyboard hook into place and starts listening for input events.
         /// </summary>
         void Listen();


### PR DESCRIPTION
We have now the InputSource.UnsetHookOnReceiverDead property where the library user can control if the hook should be removed on event receiver dead.

Reference: #18 